### PR TITLE
Critical dupe prevention flaw

### DIFF
--- a/bots.rb
+++ b/bots.rb
@@ -34,7 +34,7 @@ class MyBot < Ebooks::Bot
   end
 
   def on_startup
-    @pics = Dir.entries("pictures/") - %w[.. . .DS_Store].sort
+    @pics = (Dir.entries("pictures/") - %w[.. . .DS_Store]).sort()
     log @pics.take(5) # poll for consistency and tracking purposes.
     @status_count = twitter.user.statuses_count
     


### PR DESCRIPTION
on_startup is currently sorting the list %w[.. . .DS_Store], not the directory listing with those items removed
